### PR TITLE
platform-controller domain tenants

### DIFF
--- a/cmd/platform-controller/main.go
+++ b/cmd/platform-controller/main.go
@@ -59,6 +59,7 @@ func main() {
 		kubeInformerFactory.Core().V1().ConfigMaps(),
 		platformInformerFactory.Platform().V1alpha1().Platforms(),
 		platformInformerFactory.Platform().V1alpha1().Tenants(),
+		platformInformerFactory.Platform().V1alpha1().Domains(),
 		eventBroadcaster,
 		messaging.DefaultMessagingPublisher())
 

--- a/internal/controllers/platform/platform_controller.go
+++ b/internal/controllers/platform/platform_controller.go
@@ -55,6 +55,9 @@ type PlatformController struct {
 	tenantInformer    informers.TenantInformer
 	tenantsLister     listers.TenantLister
 	tenantsSynced     cache.InformerSynced
+	domainInformer    informers.DomainInformer
+	domainsLister     listers.DomainLister
+	domainsSynced     cache.InformerSynced
 
 	// recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
@@ -76,6 +79,7 @@ func NewPlatformController(
 	configMapInformer coreInformers.ConfigMapInformer,
 	platformInformer informers.PlatformInformer,
 	tenantInformer informers.TenantInformer,
+	domainInformer informers.DomainInformer,
 	eventBroadcaster record.EventBroadcaster,
 	messagingPublisher messaging.MessagingPublisher,
 ) *PlatformController {
@@ -90,6 +94,9 @@ func NewPlatformController(
 		tenantInformer:    tenantInformer,
 		tenantsLister:     tenantInformer.Lister(),
 		tenantsSynced:     tenantInformer.Informer().HasSynced,
+		domainInformer:    domainInformer,
+		domainsLister:     domainInformer.Lister(),
+		domainsSynced:     domainInformer.Informer().HasSynced,
 
 		recorder:           &record.FakeRecorder{},
 		workqueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "platform"),
@@ -127,6 +134,33 @@ func NewPlatformController(
 			tenant := obj.(*platformv1.Tenant)
 			klog.V(4).InfoS("tenant deleted", "name", tenant.Name, "namespace", tenant.Namespace)
 			controller.enqueuePlatformByTenant(tenant)
+		},
+	})
+
+	// Set up an event handler for when Domain resources change
+	domainInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			domain := obj.(*platformv1.Domain)
+			klog.V(4).InfoS("domain added", "name", domain.Name, "namespace", domain.Namespace)
+			controller.enqueuePlatformByDomain(domain)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldD := oldObj.(*platformv1.Domain)
+			newD := newObj.(*platformv1.Domain)
+			specChanged := !reflect.DeepEqual(oldD.Spec, newD.Spec)
+			if specChanged {
+				klog.V(4).InfoS("domain updated", "name", newD.Name, "namespace", newD.Namespace)
+				controller.enqueuePlatformByDomain(newD)
+
+				if platformChanged := oldD.Spec.PlatformRef != newD.Spec.PlatformRef; platformChanged {
+					controller.enqueuePlatformByDomain(oldD)
+				}
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			domain := obj.(*platformv1.Tenant)
+			klog.V(4).InfoS("domain deleted", "name", domain.Name, "namespace", domain.Namespace)
+			controller.enqueuePlatformByTenant(domain)
 		},
 	})
 
@@ -284,46 +318,38 @@ func (c *PlatformController) syncHandler(key string) error {
 	}
 	tenants = tenants[:n]
 
-	outputConfigMapName := fmt.Sprintf("%s-tenants", platform.Name)
-	tenantsConfigMap := c.generateTenantsConfigMap(platform, tenants, outputConfigMapName)
-	outputConfigMap, err := c.configMapsLister.ConfigMaps(platform.Spec.TargetNamespace).Get(outputConfigMapName)
-	if errors.IsNotFound(err) {
-		outputConfigMap, err = c.kubeClientset.CoreV1().ConfigMaps(platform.Spec.TargetNamespace).Create(context.TODO(), tenantsConfigMap, metav1.CreateOptions{})
-	}
-
-	// If an error occurs during Get/Create, we'll requeue the item so we can
-	// attempt processing again later. This could have been caused by a
-	// temporary network failure, or any other transient reason.
+	domains, err := c.domainInformer.Lister().List(labels.Everything())
 	if err != nil {
-		c.updateStatus(platform, false, "Sync failed")
 		return err
 	}
 
-	// If the ConfigMap is not controlled by this Platform resource, we should log
-	// a warning to the event recorder and return error msg.
-	if !metav1.IsControlledBy(outputConfigMap, platform) {
-		msg := fmt.Sprintf("Resource %q already exists and is not managed by Platform", outputConfigMap.Name)
-		c.recorder.Event(platform, corev1.EventTypeWarning, ErrResourceExists, msg)
-		return nil
-	}
-
-	// If the existing ConfigMap data differs from the aggregation result we
-	// should update the ConfigMap resource.
-	if !reflect.DeepEqual(tenantsConfigMap.Data, outputConfigMap.Data) {
-		klog.V(4).Infof("Tenant config changed")
-		err = c.kubeClientset.CoreV1().ConfigMaps(tenantsConfigMap.Namespace).Delete(context.TODO(), tenantsConfigMap.Name, metav1.DeleteOptions{})
-		if err == nil {
-			_, err = c.kubeClientset.CoreV1().ConfigMaps(tenantsConfigMap.Namespace).Create(context.TODO(), tenantsConfigMap, metav1.CreateOptions{})
+	n = 0
+	for _, d := range domains {
+		if d.Spec.PlatformRef == platform.Name {
+			domains[n] = d
+			n++
 		}
 	}
+	domains = domains[:n]
 
-	// If an error occurs during Update, we'll requeue the item so we can
+	platformCfgMap := c.genPlatformTenantsCfgMap(platform, tenants)
+	err = c.syncConfigMap(platformCfgMap, platform)
+
+	// If an error occurs we'll requeue the item so we can
 	// attempt processing again later. This could have been caused by a
 	// temporary network failure, or any other transient reason.
 	if err != nil {
 		c.updateStatus(platform, false, "Sync failed: "+err.Error())
 		c.recorder.Event(platform, corev1.EventTypeWarning, "Synced failed", err.Error())
 		return err
+	}
+
+	for _, d := range domains {
+		domainCfgMap := c.genDomainTenantsCfgMap(platform, tenants, d)
+		err = c.syncConfigMap(domainCfgMap, platform)
+		if err != nil {
+			c.recorder.Event(d, corev1.EventTypeWarning, "Synced failed", err.Error())
+		}
 	}
 
 	// Finally, we update the status block of the Platform resource to reflect the
@@ -341,6 +367,37 @@ func (c *PlatformController) syncHandler(key string) error {
 	}
 	return nil
 
+}
+
+func (c *PlatformController) syncConfigMap(desiredCfgMap *corev1.ConfigMap, platform *platformv1.Platform) error {
+	existingCfgMap, err := c.configMapsLister.ConfigMaps(desiredCfgMap.Namespace).Get(desiredCfgMap.Name)
+	if errors.IsNotFound(err) {
+		existingCfgMap, err = c.kubeClientset.CoreV1().ConfigMaps(desiredCfgMap.Namespace).Create(context.TODO(), desiredCfgMap, metav1.CreateOptions{})
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// If the ConfigMap is not controlled by this Platform resource, we should log
+	// a warning to the event recorder and return error msg.
+	if !metav1.IsControlledBy(existingCfgMap, platform) {
+		msg := fmt.Sprintf("Resource %q already exists and is not managed by Platform.", existingCfgMap.Name)
+		c.recorder.Event(platform, corev1.EventTypeWarning, ErrResourceExists, msg)
+		return nil
+	}
+
+	// If the existing ConfigMap data differs from the aggregation result we
+	// should update the ConfigMap resource.
+	if !reflect.DeepEqual(desiredCfgMap.Data, existingCfgMap.Data) {
+		klog.V(4).Infof("Config map %s changed.", desiredCfgMap.Name)
+		err = c.kubeClientset.CoreV1().ConfigMaps(desiredCfgMap.Namespace).Delete(context.TODO(), desiredCfgMap.Name, metav1.DeleteOptions{})
+		if err == nil {
+			_, err = c.kubeClientset.CoreV1().ConfigMaps(desiredCfgMap.Namespace).Create(context.TODO(), desiredCfgMap, metav1.CreateOptions{})
+		}
+	}
+
+	return err
 }
 
 // resetStatus resets the conditions of the Platform to meta.Condition
@@ -394,11 +451,17 @@ func (c *PlatformController) enqueuePlatformByTenant(tenant *platformv1.Tenant) 
 	c.workqueue.Add(platformRef)
 }
 
+func (c *PlatformController) enqueuePlatformByDomain(domain *platformv1.Domain) {
+	platformRef := domain.Spec.PlatformRef
+	c.workqueue.Add(platformRef)
+}
+
 func (c *PlatformController) enqueuePlatform(platform *platformv1.Platform) {
 	c.workqueue.Add(platform.Name)
 }
 
-func (c *PlatformController) generateTenantsConfigMap(platform *platformv1.Platform, tenants []*platformv1.Tenant, outputName string) *corev1.ConfigMap {
+func (c *PlatformController) genPlatformTenantsCfgMap(platform *platformv1.Platform, tenants []*platformv1.Tenant) *corev1.ConfigMap {
+	cfgMapName := fmt.Sprintf("%s-tenants", platform.Name)
 	tenantData := map[string]string{}
 	for _, tenant := range tenants {
 		tenantData[fmt.Sprintf("MultiTenancy__Tenants__%s__TenantId", tenant.Name)] = tenant.Spec.Id
@@ -407,12 +470,45 @@ func (c *PlatformController) generateTenantsConfigMap(platform *platformv1.Platf
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: outputName,
+			Name: cfgMapName,
 			Labels: map[string]string{
 				controllers.PlatformLabelName: platform.Name,
 				controllers.DomainLabelName:   controllers.GlobalDomainLabelValue,
 			},
 			Namespace: platform.Spec.TargetNamespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(platform, v1alpha1.SchemeGroupVersion.WithKind("Platform")),
+			},
+		},
+		Data:      tenantData,
+		Immutable: func(b bool) *bool { return &b }(true),
+	}
+}
+
+func (c *PlatformController) genDomainTenantsCfgMap(platform *platformv1.Platform, tenants []*platformv1.Tenant, domain *platformv1.Domain) *corev1.ConfigMap {
+	cfgMapName := fmt.Sprintf("%s-tenants", domain.Name)
+	tenantData := map[string]string{}
+	for _, tenant := range tenants {
+		tenantHasAccessToDomain := false
+		if tenant.Spec.Enabled {
+			for _, d := range tenant.Spec.DomainRefs {
+				if d == domain.Name {
+					tenantHasAccessToDomain = true
+					break
+				}
+			}
+		}
+		tenantData[fmt.Sprintf("MultiTenancy__Tenants__%s__Enabled", tenant.Name)] = strconv.FormatBool(tenant.Spec.Enabled && tenantHasAccessToDomain)
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cfgMapName,
+			Labels: map[string]string{
+				controllers.PlatformLabelName: platform.Name,
+				controllers.DomainLabelName:   domain.Name,
+			},
+			Namespace: domain.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(platform, v1alpha1.SchemeGroupVersion.WithKind("Platform")),
 			},

--- a/internal/controllers/platform/platform_controller.go
+++ b/internal/controllers/platform/platform_controller.go
@@ -158,9 +158,9 @@ func NewPlatformController(
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			domain := obj.(*platformv1.Tenant)
+			domain := obj.(*platformv1.Domain)
 			klog.V(4).InfoS("domain deleted", "name", domain.Name, "namespace", domain.Namespace)
-			controller.enqueuePlatformByTenant(domain)
+			controller.enqueuePlatformByDomain(domain)
 		},
 	})
 

--- a/internal/controllers/platform/platform_controller_test.go
+++ b/internal/controllers/platform/platform_controller_test.go
@@ -22,8 +22,8 @@ func TestPlatformController_processNextWorkItem(t *testing.T) {
 	t.Run("one platform with two tenants", func(t *testing.T) {
 		// Arrange
 		platform := _newPlatform("qa", "charismaonline.qa")
-		tenant1 := _newTenant("tenant1", "charismaonline.qa")
-		tenant2 := _newTenant("tenant2", "charismaonline.qa")
+		tenant1 := _newTenant("tenant1", "charismaonline.qa", []string{})
+		tenant2 := _newTenant("tenant2", "charismaonline.qa", []string{})
 
 		c, msgChan := _runController([]runtime.Object{platform, tenant1, tenant2})
 		if c.workqueue.Len() != 1 {
@@ -62,10 +62,52 @@ func TestPlatformController_processNextWorkItem(t *testing.T) {
 		}
 	})
 
+	t.Run("one platform with two tenants and one domain", func(t *testing.T) {
+		// Arrange
+		platform := _newPlatform("qa", "charismaonline.qa")
+		domain := _newDomain("qa-r7d", "origination", platform.Name)
+		tenant1 := _newTenant("tenant1", platform.Name, []string{domain.Name})
+		tenant2 := _newTenant("tenant2", platform.Name, []string{})
+
+		c, msgChan := _runController([]runtime.Object{platform, domain, tenant1, tenant2})
+		if c.workqueue.Len() != 1 {
+			t.Error("queue should have only 1 item, but it has", c.workqueue.Len())
+		}
+
+		// Act
+		if result := c.processNextWorkItem(); !result {
+			t.Error("processing failed")
+		}
+
+		// Assert
+		if c.workqueue.Len() != 0 {
+			item, _ := c.workqueue.Get()
+			t.Error("queue should be empty, but contains ", item)
+		}
+
+		output, err := c.kubeClientset.CoreV1().ConfigMaps(domain.Namespace).Get(context.TODO(), "origination-tenants", metav1.GetOptions{})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		expectedOutput := map[string]string{
+			"MultiTenancy__Tenants__tenant1__Enabled": "true",
+			"MultiTenancy__Tenants__tenant2__Enabled": "false",
+		}
+		if !reflect.DeepEqual(output.Data, expectedOutput) {
+			t.Error("expected output config ", expectedOutput, ", got", output.Data)
+		}
+
+		msg := <-msgChan
+		if msg.Topic != syncedSuccessfullyTopic {
+			t.Error("expected message pblished to topic ", syncedSuccessfullyTopic, ", got", msg.Topic)
+		}
+	})
+
 	t.Run("orphan tenants", func(t *testing.T) {
 		// Arrange
-		tenant1 := _newTenant("tenant1", "charismaonline.qa")
-		tenant2 := _newTenant("tenant2", "charismaonline.qa")
+		tenant1 := _newTenant("tenant1", "charismaonline.qa", []string{})
+		tenant2 := _newTenant("tenant2", "charismaonline.qa", []string{})
 
 		c, _ := _runController([]runtime.Object{tenant1, tenant2})
 		if c.workqueue.Len() != 1 {
@@ -126,7 +168,7 @@ func TestPlatformController_processNextWorkItem(t *testing.T) {
 		// Arrange
 		platformQa := _newPlatform("qa", "charismaonline.qa")
 		platformUat := _newPlatform("uat", "charismaonline.uat")
-		tenant1 := _newTenant("tenant1", "charismaonline.qa")
+		tenant1 := _newTenant("tenant1", "charismaonline.qa", []string{})
 
 		c, msgChan := _runController([]runtime.Object{platformQa, platformUat, tenant1})
 		if c.workqueue.Len() != 2 {
@@ -204,7 +246,7 @@ func TestPlatformController_processNextWorkItem(t *testing.T) {
 	t.Run("tenant deleted", func(t *testing.T) {
 		// Arrange
 		platformQa := _newPlatform("qa", "charismaonline.qa")
-		tenant1 := _newTenant("tenant1", "charismaonline.qa")
+		tenant1 := _newTenant("tenant1", "charismaonline.qa", []string{})
 
 		c, msgChan := _runController([]runtime.Object{platformQa, tenant1})
 		if c.workqueue.Len() != 1 {
@@ -267,7 +309,7 @@ func _newPlatform(ns, name string) *platformv1.Platform {
 	}
 }
 
-func _newTenant(name, platform string) *platformv1.Tenant {
+func _newTenant(name, platform string, domains []string) *platformv1.Tenant {
 	return &platformv1.Tenant{
 		TypeMeta: metav1.TypeMeta{APIVersion: platformv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{
@@ -279,6 +321,20 @@ func _newTenant(name, platform string) *platformv1.Tenant {
 			Description: name + " description",
 			Id:          uuid.New().String(),
 			Enabled:     true,
+			DomainRefs:  domains,
+		},
+	}
+}
+
+func _newDomain(ns, name, platform string) *platformv1.Domain {
+	return &platformv1.Domain{
+		TypeMeta: metav1.TypeMeta{APIVersion: platformv1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: platformv1.DomainSpec{
+			PlatformRef: platform,
 		},
 	}
 }
@@ -293,8 +349,12 @@ func _runController(objects []runtime.Object) (*PlatformController, chan messagi
 	msgChan := make(chan messaging.RcvMsg)
 	msgPublisher := messaging.MessagingPublisherMock(msgChan)
 
-	c := NewPlatformController(kubeClient, platformClient, kubeInformerFactory.Core().V1().ConfigMaps(),
-		platformInformerFactory.Platform().V1alpha1().Platforms(), platformInformerFactory.Platform().V1alpha1().Tenants(), nil, msgPublisher)
+	c := NewPlatformController(kubeClient, platformClient,
+		kubeInformerFactory.Core().V1().ConfigMaps(),
+		platformInformerFactory.Platform().V1alpha1().Platforms(),
+		platformInformerFactory.Platform().V1alpha1().Tenants(),
+		platformInformerFactory.Platform().V1alpha1().Domains(),
+		nil, msgPublisher)
 	kubeInformerFactory.Start(nil)
 	platformInformerFactory.Start(nil)
 

--- a/pkg/apis/platform/v1alpha1/register.go
+++ b/pkg/apis/platform/v1alpha1/register.go
@@ -35,6 +35,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ServiceList{},
 		&Tenant{},
 		&TenantList{},
+		&Domain{},
+		&DomainList{},
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)


### PR DESCRIPTION
Platform controller generates a cfgMap {domain}-tenants foreach platform's domain.
In this cfgMap there will be a "MultiTenancy__Tenants__{TenantCode}__Enabled" key foreach tenant based on the tenant's association with the domain.