### PR TITLE
fix: omit sourceRef.namespace when empty in HelmReleaseV2

### DIFF
--- a/internal/controllers/provisioning/provisioners/pulumi/helm_release_v2.go
+++ b/internal/controllers/provisioning/provisioners/pulumi/helm_release_v2.go
@@ -81,15 +81,18 @@ func pulumiFluxHrV2Args(target provisioning.ProvisioningTarget, hr *provisioning
 
 	switch {
 	case hr.Spec.Release.Chart != nil:
+		sourceRef := fluxcd.HelmReleaseSpecChartSpecSourceRefArgs{
+			Kind: pulumi.String(hr.Spec.Release.Chart.Spec.SourceRef.Kind),
+			Name: pulumi.String(hr.Spec.Release.Chart.Spec.SourceRef.Name),
+		}
+		if hr.Spec.Release.Chart.Spec.SourceRef.Namespace != "" {
+			sourceRef.Namespace = pulumi.StringPtr(hr.Spec.Release.Chart.Spec.SourceRef.Namespace)
+		}
 		spec.Chart = fluxcd.HelmReleaseSpecChartArgs{
 			Spec: fluxcd.HelmReleaseSpecChartSpecArgs{
-				Chart:   pulumi.String(hr.Spec.Release.Chart.Spec.Chart),
-				Version: pulumi.String(hr.Spec.Release.Chart.Spec.Version),
-				SourceRef: fluxcd.HelmReleaseSpecChartSpecSourceRefArgs{
-					Kind:      pulumi.String(hr.Spec.Release.Chart.Spec.SourceRef.Kind),
-					Name:      pulumi.String(hr.Spec.Release.Chart.Spec.SourceRef.Name),
-					Namespace: pulumi.String(hr.Spec.Release.Chart.Spec.SourceRef.Namespace),
-				},
+				Chart:     pulumi.String(hr.Spec.Release.Chart.Spec.Chart),
+				Version:   pulumi.String(hr.Spec.Release.Chart.Spec.Version),
+				SourceRef: sourceRef,
 			},
 		}
 	case hr.Spec.Release.ChartRef != nil:

--- a/internal/controllers/provisioning/provisioners/pulumi/helm_release_v2_test.go
+++ b/internal/controllers/provisioning/provisioners/pulumi/helm_release_v2_test.go
@@ -95,6 +95,25 @@ func TestPulumiFluxHrV2ArgsUsesChartRefWhenConfigured(t *testing.T) {
 	assert.IsType(t, fluxcd.HelmReleaseSpecChartRefArgs{}, spec.ChartRef)
 }
 
+func TestPulumiFluxHrV2ArgsOmitsSourceRefNamespaceWhenEmpty(t *testing.T) {
+	tenant := newTenant("tenant1", "dev")
+	hr := newHrV2("my-helm-release-v2", "dev")
+	hr.Spec.Release.Chart.Spec.SourceRef.Namespace = ""
+
+	args, err := pulumiFluxHrV2Args(tenant, hr)
+
+	assert.NoError(t, err)
+	spec, ok := args.Spec.(fluxcd.HelmReleaseSpecArgs)
+	assert.True(t, ok)
+	chart, ok := spec.Chart.(fluxcd.HelmReleaseSpecChartArgs)
+	assert.True(t, ok)
+	chartSpec, ok := chart.Spec.(fluxcd.HelmReleaseSpecChartSpecArgs)
+	assert.True(t, ok)
+	sourceRef, ok := chartSpec.SourceRef.(fluxcd.HelmReleaseSpecChartSpecSourceRefArgs)
+	assert.True(t, ok)
+	assert.Nil(t, sourceRef.Namespace)
+}
+
 func TestPulumiFluxHrV2ArgsErrorsWhenChartConfigurationMissing(t *testing.T) {
 	tenant := newTenant("tenant1", "dev")
 	hr := newHrV2("my-helm-release-v2", "dev")


### PR DESCRIPTION
When spec.chart.spec.sourceRef.namespace is not set, passing pulumi.String(`) caused the Kubernetes API to reject the HelmRelease with: spec.chart.spec.sourceRef.namespace in body should be at least 1 chars long. Only set Namespace when non-empty using pulumi.StringPtr, consistent with ChartRef.Namespace handling. Added a regression test.